### PR TITLE
Fix CLI usage command name

### DIFF
--- a/austin_web/__main__.py
+++ b/austin_web/__main__.py
@@ -52,7 +52,7 @@ class AustinWebArgumentParser(AustinArgumentParser):
     """AustinWeb command line parser."""
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(name="austin-tui", full=False, alt_format=False)
+        super().__init__(name="austin-web", full=False, alt_format=False)
 
         # ---- Serve command ----
         self.add_argument(


### PR DESCRIPTION
```
❯ austin-web --help
usage: austin-tui [-h] [-C] [-e] [-x EXPOSURE] [-i INTERVAL] [-m] [-p PID] [-s] [-t TIMEOUT] [-S] [-H HOST] [-P PORT] [-c COMPILE] ...

positional arguments:
  command               The command to execute if no PID is provided, followed by its arguments.
```

Right now it says `usage: autsin-tui`